### PR TITLE
fix bug on .ddev/initialize.sh

### DIFF
--- a/.ddev/initialize.sh
+++ b/.ddev/initialize.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[0;33m'


### PR DESCRIPTION
error after execute `make init` and downloading grav cms:
```bash
make: .ddev/initialize.sh: Command not found
make: *** [Makefile:10: init] Error 127
```